### PR TITLE
``` refactor: Remove geração de .env e simplifica deploy

### DIFF
--- a/build/scripts/deploy.sh
+++ b/build/scripts/deploy.sh
@@ -3,30 +3,6 @@
 set -e
 
 echo "🔧 Exportando variáveis de ambiente..."
-
-ENV_FILE=".env.runtime"
-
-cat > $ENV_FILE <<EOF
-NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-NODE_ENV=${NODE_ENV}
-COOKIE_SECRET=${COOKIE_SECRET}
-GEMINI_API_KEY=${GEMINI_API_KEY}
-HOST=${HOST}
-JWT_SECRET=${JWT_SECRET}
-OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
-PGDATABASE=${PGDATABASE}
-PGHOST=${PGHOST}
-PGPASSWORD=${PGPASSWORD}
-PGUSER=${PGUSER}
-PORT=${PORT}
-UPSTASH_REDIS_URL=${UPSTASH_REDIS_URL}
-REDIS_PASSWORD=${REDIS_PASSWORD}
-RESEND_API_KEY=${RESEND_API_KEY}
-IMAGE_TAG=${IMAGE_TAG}
-EOF
-
-echo "📄 .env gerado com sucesso:"
-cat $ENV_FILE
 echo "🏷️ Usando tag da imagem: ${IMAGE_TAG}"
 echo "🚀 Subindo containers com docker compose..."
 
@@ -43,8 +19,8 @@ echo "NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL"
 echo "IMAGE_TAG=$IMAGE_TAG"
 echo "NODE_ENV=$NODE_ENV"
 
-docker compose --env-file $ENV_FILE -f docker-compose.apps.yml pull
-docker compose --env-file $ENV_FILE -f docker-compose.apps.yml down -v --remove-orphans
-docker compose --env-file $ENV_FILE -f docker-compose.apps.yml up -d
+docker compose -f docker-compose.apps.yml pull
+docker compose -f docker-compose.apps.yml down -v --remove-orphans
+docker compose -f docker-compose.apps.yml up -d
 
 echo "✅ Deploy finalizado com sucesso!"

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -3,6 +3,15 @@ import { z } from 'zod'
 import { existsSync } from 'fs';
 import { resolve } from 'path';
 
+console.log('🐛 DEBUG: Variáveis de ambiente disponíveis no process.env:');
+for (const key of Object.keys(process.env)) {
+    if (key.startsWith('PG') || key.startsWith('REDIS') || key.startsWith('JWT') || key.includes('SECRET') || key.includes('API_KEY')) {
+        console.log(`${key}=***`);
+    } else {
+        console.log(`${key}=${process.env[key]}`);
+    }
+}
+
 
 function findMonorepoRootEnv() {
     const filenames = ['.env.prod', '.env'];
@@ -28,8 +37,7 @@ if (envPath && process.env.NODE_ENV !== 'production') {
     dotenvConfig({ path: envPath });
     console.log('🔍 Carregado .env de:', envPath);
 } else {
-    console.log('⚠️ Arquivo .env não encontrado.');
-    console.log('⚠️ Rodando variáveis de ambiente do sistema.');
+    console.log('⚠️ .env não carregado (modo produção ou arquivo ausente).');
 }
 
 const preprocessEmptyString = (val: unknown) => (val === '' ? undefined : val);


### PR DESCRIPTION
Remove a geração do arquivo .env.runtime no script de deploy e simplifica o comando docker-compose, utilizando diretamente as variáveis de ambiente do sistema. Adiciona logs de debug para as variáveis de ambiente.
```
