### PR TITLE
feat: Atualiza Dockerfiles para copiar script de inicialização do builder

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=topobre-builder /topobre/packages/winston/dist ./packages/winston/di
 RUN pnpm install --prod --frozen-lockfile
 # COPY --from=topobre-builder /topobre/node_modules ./node_modules
 
-COPY ../../build/scripts/start.sh ./start.sh
+COPY --from=topobre-builder /topobre/build/scripts/start.sh ./start.sh
 RUN chmod +x ./start.sh
 ENTRYPOINT ["./start.sh"]
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=topobre-builder /topobre/apps/web/package.json ./apps/web/package.js
 
 RUN pnpm install --prod --frozen-lockfile --filter=@topobre/web
 
-COPY ../../build/scripts/start.sh ./start.sh
+COPY --from=topobre-builder /topobre/build/scripts/start.sh ./start.sh
 RUN chmod +x ./start.sh
 ENTRYPOINT ["./start.sh"]
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=topobre-builder /topobre/packages/gemini/dist ./packages/gemini/dist
 RUN pnpm install --prod --frozen-lockfile 
 # COPY --from=topobre-builder /topobre/node_modules ./node_modules
 
-COPY ../../build/scripts/start.sh ./start.sh
+COPY --from=topobre-builder /topobre/build/scripts/start.sh ./start.sh
 RUN chmod +x ./start.sh
 ENTRYPOINT ["./start.sh"]
 


### PR DESCRIPTION
Move o script de inicialização para dentro do builder e ajusta os Dockerfiles para copiá-lo de lá.
