### PR TITLE
feat: Migra ioredis para Redis e ajusta configurações

### DIFF
--- a/apps/worker/debug/debugRedis.ts
+++ b/apps/worker/debug/debugRedis.ts
@@ -1,11 +1,11 @@
 // src/debug/debug-ioredis.ts
-import IORedis, { RedisOptions } from 'ioredis';
+import Redis, { RedisOptions } from 'ioredis';
 import fs from 'fs';
 import path from 'path';
 
 const logFilePath = path.resolve(__dirname, 'redis-connections.log');
 
-const OriginalRedis = IORedis;
+const OriginalRedis = Redis;
 
 class DebugRedis extends OriginalRedis {
     constructor(options?: RedisOptions | string) {

--- a/packages/bullmq/index.ts
+++ b/packages/bullmq/index.ts
@@ -1,12 +1,17 @@
 import { Queue } from 'bullmq';
 import { env } from '@topobre/env';
-import IORedis from 'ioredis';
+import Redis from 'ioredis';
 
 export const FINLOADER_QUEUE_NAME = 'finloader-file-processing';
 
-export const redisConnection = new IORedis(env.UPSTASH_REDIS_URL, { maxRetriesPerRequest: null })
+export const redisConnection = new Redis({
+  host: env.REDIS_HOST,
+  port: env.REDIS_PORT,
+  password: env.REDIS_PASSWORD,
+  maxRetriesPerRequest: null,
+  tls: {},
+})
 
-// Fila para o produtor (API) usar
 export const finloaderQueue = new Queue(FINLOADER_QUEUE_NAME, {
   connection: redisConnection
 });

--- a/packages/telemetry/index.ts
+++ b/packages/telemetry/index.ts
@@ -120,9 +120,6 @@ export function initTelemetry(config: TelemetryConfig | string) {
             '@opentelemetry/instrumentation-pg': {
                 enabled: true,
             },
-            '@opentelemetry/instrumentation-redis': {
-                enabled: false,
-            },
             '@opentelemetry/instrumentation-ioredis': {
                 enabled: true,
             }

--- a/packages/typeorm/index.ts
+++ b/packages/typeorm/index.ts
@@ -2,8 +2,6 @@ import "reflect-metadata";
 import { DataSource } from "typeorm";
 import * as path from "path";
 import { env } from "@topobre/env";
-import { Redis } from "ioredis";
-import { url } from "inspector";
 
 export * from 'typeorm';
 export * from './entities';
@@ -25,18 +23,19 @@ export const TopobreDataSource = new DataSource({
     // logging: true,
     ssl: true,
     cache: {
-        type: "redis",
+        type: "ioredis",
         alwaysEnabled: true,
-        options: {
-            url: env.UPSTASH_REDIS_URL,
-        },
         // options: {
-        //     host: env.REDIS_HOST,
-        //     port: env.REDIS_PORT,
-        //     password: env.REDIS_PASSWORD,
-        //     tls: {},
-        //     ignoreErrors: true
+        //     url: env.UPSTASH_REDIS_URL,
         // },
+        options: {
+            host: env.REDIS_HOST,
+            port: env.REDIS_PORT,
+            password: env.REDIS_PASSWORD,
+            ignoreErrors: true,
+            tls: {},
+            maxRetriesPerRequest: null,
+        },
         duration: 60000 * 1 // 5 minutos
     },
     dropSchema: false, // Não derruba o schema ao reiniciar a aplicação


### PR DESCRIPTION
Refatora a configuração do Redis para utilizar a biblioteca `redis` (ioredis) diretamente, em vez de `upstash`, e ajusta as opções de conexão para suportar host, porta, senha e TLS. Remove a instrumentação legada do Redis e atualiza a configuração do cache do TypeORM para usar ioredis.
