### PR TITLE
fix: corrige alias do finloader no package.json

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "_moduleAliases": {
-    "@topobre/finloader": "../../packages/finloader/dist",
+    "@topobre/finloader": "../finloader/dist",
     "@topobre/bullmq": "../../packages/bullmq/dist",
     "@topobre/env": "../../packages/env/dist",
     "@topobre/telemetry": "../../packages/telemetry/dist",


### PR DESCRIPTION
Ajusta o caminho do alias para o pacote finloader no arquivo package.json para refletir a estrutura de diretórios correta.
