### PR TITLE
refactor(build): remover definição de rede redundante dos arquivos YAML

### DIFF
--- a/server/grafana.yml
+++ b/server/grafana.yml
@@ -16,7 +16,3 @@ services:
       - tempo
     networks:
       - topobre-net
-
-networks:
-  topobre-net:
-    external: true

--- a/server/jaeger.yml
+++ b/server/jaeger.yml
@@ -9,7 +9,3 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
     networks:
       - topobre-net
-
-networks:
-  topobre-net:
-    external: true

--- a/server/loki.yml
+++ b/server/loki.yml
@@ -12,7 +12,3 @@ services:
       - "3100:3100"
     networks:
       - topobre-net
-
-networks:
-  topobre-net:
-    external: true

--- a/server/otel-collector.yml
+++ b/server/otel-collector.yml
@@ -16,7 +16,3 @@ services:
     restart: unless-stopped
     networks:
       - topobre-net
-
-networks:
-  topobre-net:
-    external: true

--- a/server/prometheus.yml
+++ b/server/prometheus.yml
@@ -9,7 +9,3 @@ services:
       - "9090:9090"
     networks:
       - topobre-net
-
-networks:
-  topobre-net:
-    external: true

--- a/server/tempo.yml
+++ b/server/tempo.yml
@@ -11,7 +11,3 @@ services:
       - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml
     networks:
       - topobre-net
-
-networks:
-  topobre-net:
-    external: true


### PR DESCRIPTION
- Remove a definição da rede `topobre-net` que era redundante nos arquivos YAML.
- Simplifica a configuração dos serviços, utilizando a rede já definida externamente.
