### PR TITLE
ci(build): adiciona user id e group id dinâmicos ao docker-compose

### DIFF
--- a/build/scripts/deploy.sh
+++ b/build/scripts/deploy.sh
@@ -29,6 +29,8 @@ NODE_ENV=production
 NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 WEB_PORT=${WEB_PORT}
 IMAGE_TAG=${IMAGE_TAG}
+UID=$(id -u)
+GID=$(id -g)
 EOF
 
 echo "📄 .env.runtime gerado com sucesso:"
@@ -40,9 +42,5 @@ echo "🚀 Subindo containers com docker compose..."
 docker compose -f docker-compose.apps.yml pull
 docker compose -f docker-compose.apps.yml down -v --remove-orphans
 docker compose -f docker-compose.apps.yml up -d
-
-# echo "${cwd}"
-
-# cd ../../../ && echo "${PASS}" | sudo -S chmod 777 -R .
 
 echo "✅ Deploy finalizado com sucesso!"

--- a/server/grafana.yml
+++ b/server/grafana.yml
@@ -2,6 +2,7 @@ services:
   grafana:
     image: grafana/grafana:9.5.3
     container_name: grafana
+    user: "${UID}:${GID}"
     ports:
       - "3001:3000"
     environment:

--- a/server/infra/postgres.yml
+++ b/server/infra/postgres.yml
@@ -2,6 +2,7 @@ services:
   postgres:
     image: postgres:15-alpine
     container_name: postgres
+    user: "${UID}:${GID}"
     ports:
       - "5432:5432"
     environment:

--- a/server/loki.yml
+++ b/server/loki.yml
@@ -2,7 +2,7 @@ services:
   loki:
     image: grafana/loki:2.8.2
     container_name: loki
-    user: "1000:1000"
+    user: "${UID}:${GID}"
     command: ["-config.file=/etc/loki/loki-config.yml"]
     volumes:
       - ./loki/loki-config.yml:/etc/loki/loki-config.yml

--- a/server/nginx-manager.yml
+++ b/server/nginx-manager.yml
@@ -3,6 +3,7 @@ services:
     image: jc21/nginx-proxy-manager:latest
     container_name: ng-manager
     restart: unless-stopped
+    user: "${UID}:${GID}"
     ports:
       - '80:80'
       - '443:443'

--- a/server/otel/otel-collector-config.yml
+++ b/server/otel/otel-collector-config.yml
@@ -17,8 +17,8 @@ exporters:
     endpoint: "tempo:4317"
     tls:
       insecure: true
-  jaeger:
-    endpoint: jaeger:14250
+  otlp/jaeger:
+    endpoint: jaeger:4317
     tls:
       insecure: true
 
@@ -30,7 +30,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/tempo, jaeger]
+      exporters: [logging, otlp/tempo, otlp/jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/server/portainer.yml
+++ b/server/portainer.yml
@@ -4,6 +4,7 @@ services:
     container_name: portainer
     restart: always
     privileged: true
+    user: "${UID}:${GID}"
     ports:
       - "8000:8000"
       - "9000:9000"

--- a/server/prometheus.yml
+++ b/server/prometheus.yml
@@ -2,6 +2,7 @@ services:
   prometheus:
     image: prom/prometheus:v2.44.0
     container_name: prometheus
+    user: "${UID}:${GID}"
     command: ["--config.file=/etc/prometheus/prometheus.yml"]
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml

--- a/server/tempo.yml
+++ b/server/tempo.yml
@@ -2,8 +2,8 @@ services:
   tempo:
     image: grafana/tempo:2.4.1
     container_name: tempo
+    user: "${UID}:${GID}"
     command: ["-config.file=/etc/tempo/tempo.yaml"]
-    user: "1000:1000"
     ports:
       - "3200:3200"  # HTTP
       - "4317:4317"  # gRPC


### PR DESCRIPTION
- adiciona variáveis UID e GID ao deploy.sh para passar o id do usuário atual para o docker
- configura o usuário dos serviços no docker-compose para usar o UID e GID dinâmicos
- isso permite que os containers rodem com as permissões do usuário local, evitando problemas de permissão de arquivos
- atualiza endpoint do jaeger para otlp
