### PR TITLE
 refactor(seed): otimiza o fluxo de inicialização do datasource

### DIFF
--- a/packages/typeorm/src/seed/saveCategories.ts
+++ b/packages/typeorm/src/seed/saveCategories.ts
@@ -22,9 +22,10 @@ const categories = [
 ];
 
 export async function saveCategories(db?: DataSource | any) {
+    logger.info("[TYPEORM] Inicializando datasource...");
+    const dataSource = db ?? await TopobreDataSource.initialize();
+
     try {
-        logger.info("[TYPEORM] Inicializando datasource...");
-        const dataSource = db || await TopobreDataSource.initialize();
         const categoryRepo = dataSource.getRepository(Category);
         logger.info("[TYPEORM] Datasource conectado com sucesso.");
 
@@ -69,7 +70,7 @@ export async function saveCategories(db?: DataSource | any) {
         logger.error("[TYPEORM] Erro ao salvar categorias:", error);
         throw error;
     } finally {
-        await TopobreDataSource.destroy();
+        await dataSource.destroy();
         logger.info("[TYPEORM] Datasource encerrado.");
     }
 }


### PR DESCRIPTION
- Garante que o datasource seja inicializado antes do bloco try
- Usa a instância `dataSource` para destruir a conexão no bloco `finally`
- Remove a dupla inicialização do datasource
